### PR TITLE
Ensure hi wind blink always works

### DIFF
--- a/metar-v4.py
+++ b/metar-v4.py
@@ -252,6 +252,7 @@ cycle2_wait = .08       #For instance, VFR with 20 kts winds will have the first
 cycle3_wait = .1        #The cycle times then reflect how long each color cycle will stay on, producing blinking or flashing effects.
 cycle4_wait = .08       #Lightning effect uses the short intervals at cycle 2 and cycle 4 to create the quick flash. So be careful if you change them.
 cycle5_wait = .5
+cycle6_wait = .22       #Used only for the wind blink feature
 
 #List of METAR weather categories to designate weather in area. Many Metars will report multiple conditions, i.e. '-RA BR'.
 #The code pulls the first/main weather reported to compare against the lists below. In this example it uses the '-RA' and ignores the 'BR'.
@@ -270,8 +271,8 @@ wx_dustsandash_ck = ["DU", "SA", "HZ", "FU", "VA", "BLDU", "BLSA", "PO", "VCSS",
 wx_fog_ck = ["BR", "MIFG", "VCFG", "BCFG", "PRFG", "FG", "FZFG"]
 
 #list definitions
-cycle_wait = [cycle0_wait, cycle1_wait, cycle2_wait, cycle3_wait, cycle4_wait, cycle5_wait] #Used to create weather designation effects.
-cycles = [0,1,2,3,4,5] #Used as a index for the cycle loop.
+cycle_wait = [cycle0_wait, cycle1_wait, cycle2_wait, cycle3_wait, cycle4_wait, cycle5_wait, cycle6_wait] #Used to create weather designation effects.
+cycles = [0,1,2,3,4,5,6] #Used as a index for the cycle loop.
 legend_pins = [leg_pin_vfr, leg_pin_mvfr, leg_pin_ifr, leg_pin_lifr, leg_pin_nowx, leg_pin_hiwinds, leg_pin_lghtn, leg_pin_snow, leg_pin_rain, leg_pin_frrain, leg_pin_dustsandash, leg_pin_fog] #Used to build legend display
 
 #Setup for IC238 Light Sensor for LED Dimming, does not need to be commented out if sensor is not used, map will remain at full brightness.
@@ -1442,7 +1443,8 @@ while (outerloop):
         for cycle_num in cycles: #cycle through the strip 6 times, setting the color then displaying to create various effects.
             print(" " + str(cycle_num), end = '')
             sys.stdout.flush()
-
+            if (not hiwindblink and cycle_num == 6):
+              continue  # Skip cycle 6 unless hiwindblink is enabled
             i = 0 #Inner Loop. Increments through each LED in the strip setting the appropriate color to each individual LED.
             for airportcode in airports:
 
@@ -1487,7 +1489,7 @@ while (outerloop):
                         color = color_nowx
 
                     if i == leg_pin_hiwinds and legend_hiwinds:
-                        if (cycle_num == 3 or cycle_num == 4 or cycle_num == 5):
+                        if (cycle_num == 6):
                             color = color_black
                         else:
                             color=color_ifr
@@ -1568,7 +1570,7 @@ while (outerloop):
 
                 #Check winds and set the 2nd half of cycles to black to create blink effect
                 if hiwindblink: #bypass if "hiwindblink" is set to 0
-                    if (int(airportwinds) >= max_wind_speed and (cycle_num == 3 or cycle_num == 4 or cycle_num == 5)):
+                    if (int(airportwinds) >= max_wind_speed and (cycle_num == 6)):
                         color = color_black
                         print(("HIGH WINDS-> " + airportcode + " Winds = " + str(airportwinds) + " ")) #debug
 


### PR DESCRIPTION
Added an additional cycle that only runs if the hi wind feature is enabled.
When enabled and the winds are high the color is set to black during this cycle.

Now you can, for example, see if it is raining and windy or not.